### PR TITLE
Disable spellcheck on js repl

### DIFF
--- a/docs/fonts.html
+++ b/docs/fonts.html
@@ -288,7 +288,7 @@ Iosevka Term Extended
 <div id="setfont">
   <div class="cont">
     <div class="kb"></div>
-    <textarea class="code" rows="8"></textarea>
+    <textarea class="code" rows="8" spellcheck="false"></textarea>
     <input class="run" type="submit" value="Run (or shift-enter)"/>
   </div>
   <pre class="rslt"></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
 <div class='cont'>
   <div class='kb'></div>
   <div class='rel'>
-    <textarea class='code' rows='1'><⟜'a'⊸/ "Big Questions Notation"</textarea>
+    <textarea class='code' rows='1' spellcheck="false"><⟜'a'⊸/ "Big Questions Notation"</textarea>
     <svg class='demo' viewBox='0 -6 4 12'><path d='M1 -6H0L1 0L0 6H1L4 0z'/></svg>
   </div>
   <pre class='rslt'>"B Q N"</pre>

--- a/docs/try.html
+++ b/docs/try.html
@@ -19,7 +19,7 @@
   <a href="https://mlochbaum.github.io/BQN/" title='BQN homepage'>BQN</a>
   <div class="cont">
     <div class="kb"></div>
-    <textarea class="code" rows="8" autofocus></textarea>
+    <textarea class="code" rows="8" spellcheck="false" autofocus></textarea>
     <div class="count"></div>
     <input class="run" type="submit" value="Run (or shift-enter)"/>
     <input class="doexplain" type="button" value="Explain"/>


### PR DESCRIPTION
Doing some advent of code stuff, the spellcheck can sometimes be annoying. Didn't change anything in README.md, noticed there's some BQN code there to generate a `textarea`, not sure how it works so you can handle that one.

<img src="https://user-images.githubusercontent.com/14286382/127864562-bab2563f-e8df-458d-a4c4-596a121ef5f2.png" width="300">
