### PR TITLE
editors/emacs: fix bytecode compilation and reduce warnings

### DIFF
--- a/editors/emacs/bqn-input.el
+++ b/editors/emacs/bqn-input.el
@@ -30,23 +30,22 @@
     (define-key map [menu-bar bqn] (cons "BQN" (make-sparse-keymap "BQN")))
     map))
 
-(defun bqn--make-bqn-mode-map ()
-  (bqn--make-base-mode-map bqn-mode-map-prefix))
+;; value gets updated by initialization of bqn-mode-map-prefix
+(defvar bqn--mode-map nil
+  "The keymap for ‘bqn-mode’.")
 
 (defun bqn--set-mode-map-prefix (symbol new)
   "Recreate the prefix and the keymap."
   (set-default symbol new)
-  (setq bqn--mode-map (bqn--make-bqn-mode-map)))
+  (setq bqn--mode-map (bqn--make-base-mode-map new)))
 
 (defcustom bqn-mode-map-prefix "s-"
   "The keymap prefix for ‘bqn--mode-map’ used both to store the new value using
-  ‘set-create’ and to update ‘bqn--mode-map’ using `bqn--make-bqn-mode-map'.
+  ‘set-create’ and to update ‘bqn--mode-map’ using `bqn--make-base-mode-map'.
   Kill and re-start your BQN buffers to reflect the change."
   :type 'string
   :group 'bqn
-  :set 'bqn--set-mode-map-prefix)
-
-(defvar bqn--mode-map (bqn--make-bqn-mode-map)
-  "The keymap for ‘bqn-mode’.")
+  :set 'bqn--set-mode-map-prefix
+  :initialize 'custom-initialize-set)
 
 (provide 'bqn-input)

--- a/editors/emacs/bqn-input.el
+++ b/editors/emacs/bqn-input.el
@@ -39,9 +39,9 @@
   (setq bqn--mode-map (bqn--make-bqn-mode-map)))
 
 (defcustom bqn-mode-map-prefix "s-"
-  "The keymap prefix for ‘bqn--mode-map’ used both to store the new value
-using ‘set-create’ and to update ‘bqn--mode-map’ using
-  `bqn--make-bqn-mode-map'. Kill and re-start your BQN buffers to reflect the change."
+  "The keymap prefix for ‘bqn--mode-map’ used both to store the new value using
+  ‘set-create’ and to update ‘bqn--mode-map’ using `bqn--make-bqn-mode-map'.
+  Kill and re-start your BQN buffers to reflect the change."
   :type 'string
   :group 'bqn
   :set 'bqn--set-mode-map-prefix)

--- a/editors/emacs/bqn-input.el
+++ b/editors/emacs/bqn-input.el
@@ -3,8 +3,9 @@
 (require 'cl-lib)
 (require 'bqn-symbols)
 
-(defun bqn--make-key-command-sym (n)
-  (intern (concat "insert-sym-bqn-" n)))
+(eval-and-compile
+  (defun bqn--make-key-command-sym (n)
+    (intern (concat "insert-sym-bqn-" n))))
 
 (cl-macrolet ((make-insert-functions ()
              `(progn


### PR DESCRIPTION
This fixes a compilation error (at least for bytecode compilation) in macro expansion for `bqn-input.el` and also fixes a couple of warnings I encountered (see commit messages). 

Only remaining warning is:

```
In end of data:
bqn-mode.el:40:4: Warning: the function `speedbar-add-supported-extension' is
    not known to be defined.
```

But this seemed quite harmless to me, so I haven't investigated so far, how you can avoid that.