### PR TITLE
emacs/bqn-symbols.el: fix mapping for space

### DIFF
--- a/editors/emacs/bqn-input.el
+++ b/editors/emacs/bqn-input.el
@@ -24,9 +24,8 @@
 (defun bqn--make-base-mode-map (prefix)
   (let ((map (make-sparse-keymap)))
     (dolist (command bqn--symbols)
-      (let ((key-sequence (caddr command)))
-        (dolist (s (if (listp key-sequence) key-sequence (list key-sequence)))
-          (define-key map (bqn--kbd (concat prefix s)) (bqn--make-key-command-sym (car command))))))
+      (let ((key (caddr command)))
+        (define-key map (bqn--kbd (concat prefix s)) (bqn--make-key-command-sym (car command)))))
     (define-key map [menu-bar bqn] (cons "BQN" (make-sparse-keymap "BQN")))
     map))
 

--- a/editors/emacs/bqn-input.el
+++ b/editors/emacs/bqn-input.el
@@ -24,8 +24,8 @@
 (defun bqn--make-base-mode-map (prefix)
   (let ((map (make-sparse-keymap)))
     (dolist (command bqn--symbols)
-      (let ((key (caddr command)))
-        (define-key map (bqn--kbd (concat prefix s)) (bqn--make-key-command-sym (car command)))))
+      (let ((key (single-key-description (string-to-char (caddr command)))))
+        (define-key map (bqn--kbd (concat prefix key)) (bqn--make-key-command-sym (car command)))))
     (define-key map [menu-bar bqn] (cons "BQN" (make-sparse-keymap "BQN")))
     map))
 

--- a/editors/emacs/bqn-symbols.el
+++ b/editors/emacs/bqn-symbols.el
@@ -139,7 +139,7 @@
                        ("left-double-arrow" "⇐" "?")
 
                        ;; Space bar
-                       ("ligature" "‿" "SPC")
+                       ("ligature" "‿" " ")
                        ))
 
 (provide 'bqn-symbols)


### PR DESCRIPTION
The “key” needs to be the plain ASCII space instead of "SPC". With this
change, space works properly for both the BQN-Z input mode and the
modifier-based mode-map.

Thanks to @leahneukirchen for pointing this out.