### PR TITLE
emacs/bqn-symbols.el: properly escape brackets

### DIFF
--- a/editors/emacs/bqn-symbols.el
+++ b/editors/emacs/bqn-symbols.el
@@ -29,10 +29,10 @@
                        ("thorn" "⍕" ?*)
                        ;; 9
                        ("high-minus" "¯" ?9)
-                       ("open-angle" "⟨" ?()
+                       ("open-angle" "⟨" ?\()
                        ;; 0
                        ("bullet" "•" ?0)
-                       ("close-angle" "⟩" ?))
+                       ("close-angle" "⟩" ?\))
                        ;; -
                        ("division-sign" "÷" ?-)
                        ("root" "√" ?_)
@@ -69,10 +69,10 @@
                        ("pi" "π" ?p)
                        ("iota" "⍳" ?P)
                        ;; [
-                       ("left-arrow" "←" ?[)
+                       ("left-arrow" "←" ?\[)
                        ("left-tack" "⊣" ?{)
                        ;; ]
-                       ("right-arrow" "→" ?])
+                       ("right-arrow" "→" ?\])
                        ("right-tack" "⊢" ?})
                        ;; \
                        ("backslash" "\\" ?\\)


### PR DESCRIPTION
() and [] are part of elisp syntax, so they should be escaped in
character literals (but don't have to). This change fixes a warning I
missed previously.

Hopefully this is the last PR I have to bother you with today…