### PR TITLE
:memo: Corrections to BQN Combinator Birds

### DIFF
--- a/doc/birds.md
+++ b/doc/birds.md
@@ -9,10 +9,10 @@ Some people consider it reasonable to name [combinators](primitive.md#modifiers)
 | `⊣`     | Identity  | `I`   | Kestrel      | `K`
 | `⊢`     | Identity  | `I`   |              | `KI`
 | `∘`     | Bluebird  | `B`   | Blackbird    | `B₁`
-| `○`     | Bluebird  | `B`   | Psi?         | `D₂`-like: `labcd.a(bc)(bd)`
+| `○`     | Bluebird  | `B`   | Psi          | `ψ`
 | `˙`     | Kestrel   | `K`   |              | `KK`
-| `⊸`     |           | `R*S` | Queer        | `Q`
-| `⟜`     | Starling  | `S`   | ~Dove        | `D`-like: `labcd.ac(bd)`
+| `⊸`     |           | `BSC` | ~Dove        | `D`-like: `labcd.a(bc)d`
+| `⟜`     | Starling  | `S`   | Dove         | `D`
 | `˜`     | Warbler   | `W`   | Cardinal     | `C`
 | `k G H` | Dove      | `D`   | Eagle        | `E`
 | `F G H` | Phoenix   | `S'`  | Golden Eagle | `Ê`-like: `labcde.a(bde)(cde)`
@@ -22,3 +22,8 @@ The name "Golden Eagle" is a [fever dream](https://nitter.net/code_report/status
 Lambda calculus doesn't have BQN's polymorphism on one or two arguments, so each BQN combinator corresponds to two lambda calculus forms depending on the number of arguments, giving the two columns of birds above.
 
 Inputs are mapped to lambda calculus arguments according to the ordering `𝔽𝔾𝕨𝕩`, and `GFH` for a 3-train `F G H`. For example, when I write that the combination `𝕨 𝔽˜ 𝕩` corresponds to a call of `C` or `labc.acb`, `a` is `𝔽` and `bc` are `𝕨𝕩`.
+
+**List of combinator bird compendiums:**
+1. [Angelfire Combinator Birds](https://www.angelfire.com/tx4/cus/combinator/birds.html)
+2. [Fantasy Land Birds](https://github.com/fantasyland/fantasy-birds)
+3. [Lähteenmäki Combinator Birds](https://blog.lahteenmaki.net/combinator-birds.html)

--- a/doc/birds.md
+++ b/doc/birds.md
@@ -24,6 +24,5 @@ Lambda calculus doesn't have BQN's polymorphism on one or two arguments, so each
 Inputs are mapped to lambda calculus arguments according to the ordering `𝔽𝔾𝕨𝕩`, and `GFH` for a 3-train `F G H`. For example, when I write that the combination `𝕨 𝔽˜ 𝕩` corresponds to a call of `C` or `labc.acb`, `a` is `𝔽` and `bc` are `𝕨𝕩`.
 
 **List of combinator bird compendiums:**
-1. [Angelfire Combinator Birds](https://www.angelfire.com/tx4/cus/combinator/birds.html)
-2. [Fantasy Land Birds](https://github.com/fantasyland/fantasy-birds)
-3. [Lähteenmäki Combinator Birds](https://blog.lahteenmaki.net/combinator-birds.html)
+* [Angelfire Combinator Birds](https://www.angelfire.com/tx4/cus/combinator/birds.html)
+* [Fantasy Land Birds](https://github.com/fantasyland/fantasy-birds)

--- a/doc/birds.md
+++ b/doc/birds.md
@@ -12,7 +12,7 @@ Some people consider it reasonable to name [combinators](primitive.md#modifiers)
 | `○`     | Bluebird  | `B`   | Psi          | `ψ`
 | `˙`     | Kestrel   | `K`   |              | `KK`
 | `⊸`     |           | `BSC` | ~Dove        | `D`-like: `labcd.a(bc)d`
-| `⟜`     | Starling  | `S`   | Dove         | `D`
+| `⟜`     | Starling  | `S`   | ~Dove        | `D`-like: `labcd.ac(bd)`
 | `˜`     | Warbler   | `W`   | Cardinal     | `C`
 | `k G H` | Dove      | `D`   | Eagle        | `E`
 | `F G H` | Phoenix   | `S'`  | Golden Eagle | `Ê`-like: `labcde.a(bde)(cde)`

--- a/doc/birds.md
+++ b/doc/birds.md
@@ -4,18 +4,18 @@
 
 Some people consider it reasonable to name [combinators](primitive.md#modifiers) after types of birds. [Here's](https://www.angelfire.com/tx4/cus/combinator/birds.html) one compendium of such names, albeit still missing the Phoenix or `S'` combinator `labcd.a(bd)(cd)` ([this one](https://hackage.haskell.org/package/data-aviary-0.4.0/docs/Data-Aviary-Birds.html) has more). There is something wrong with these people. Some of these birds are not even real. "Quixotic bird"? Have you not heard of a quail? Nonetheless, I don't judge such afflicted souls (certainly not publicly), and have provided this translation table to explain BQN in terms they can understand.
 
-| BQN     | Bird 1    |  1    | Bird 2       |  2
-|:-------:|-----------|-------|--------------|---------
-| `⊣`     | Identity  | `I`   | Kestrel      | `K`
-| `⊢`     | Identity  | `I`   |              | `KI`
-| `∘`     | Bluebird  | `B`   | Blackbird    | `B₁`
-| `○`     | Bluebird  | `B`   | Psi          | `ψ`
-| `˙`     | Kestrel   | `K`   |              | `KK`
-| `⊸`     |           | `BSC` | ~Dove        | `D`-like: `labcd.a(bc)d`
-| `⟜`     | Starling  | `S`   | ~Dove        | `D`-like: `labcd.ac(bd)`
-| `˜`     | Warbler   | `W`   | Cardinal     | `C`
-| `k G H` | Dove      | `D`   | Eagle        | `E`
-| `F G H` | Phoenix   | `S'`  | Golden Eagle | `Ê`-like: `labcde.a(bde)(cde)`
+|   BQN   | Bird 1   | 1        | Bird 2       | 2                              |
+| :-----: | -------- | -------- | ------------ | ------------------------------ |
+|   `⊣`   | Identity | `I`      | Kestrel      | `K`                            |
+|   `⊢`   | Identity | `I`      |              | `KI`                           |
+|   `∘`   | Bluebird | `B`      | Blackbird    | `B₁`                           |
+|   `○`   | Bluebird | `B`      | Psi          | `ψ`                            |
+|   `˙`   | Kestrel  | `K`      |              | `KK`                           |
+|   `⊸`   |          | `B1CBSC` | ~Dove        | `D`-like: `labcd.b(ac)d`       |
+|   `⟜`   | Starling | `S`      | ~Dove        | `D`-like: `labcd.ac(bd)`       |
+|   `˜`   | Warbler  | `W`      | Cardinal     | `C`                            |
+| `k G H` | Dove     | `D`      | Eagle        | `E`                            |
+| `F G H` | Phoenix  | `S'`     | Golden Eagle | `Ê`-like: `labcde.a(bde)(cde)` |
 
 The name "Golden Eagle" is a [fever dream](https://nitter.net/code_report/status/1440208242529882112#m) of bird enthusiast Conor Hoekstra, who saw it emerge disordered from the Bald Eagle when arguments `fg` are set equal to `cd`.
 

--- a/doc/birds.md
+++ b/doc/birds.md
@@ -25,4 +25,4 @@ Inputs are mapped to lambda calculus arguments according to the ordering `𝔽�
 
 **List of combinator bird compendiums:**
 * [Angelfire Combinator Birds](https://www.angelfire.com/tx4/cus/combinator/birds.html)
-* [Fantasy Land Birds](https://github.com/fantasyland/fantasy-birds)
+* [Lähteenmäki Combinator Birds](https://blog.lahteenmaki.net/combinator-birds.html)

--- a/docs/doc/birds.html
+++ b/docs/doc/birds.html
@@ -95,5 +95,5 @@
 <p><strong>List of combinator bird compendiums:</strong></p>
 <ul>
 <li><a href="https://www.angelfire.com/tx4/cus/combinator/birds.html">Angelfire Combinator Birds</a></li>
-<li><a href="https://github.com/fantasyland/fantasy-birds">Fantasy Land Birds</a></li>
+<li><a href="https://blog.lahteenmaki.net/combinator-birds.html">Lähteenmäki Combinator Birds</a></li>
 </ul>

--- a/docs/doc/birds.html
+++ b/docs/doc/birds.html
@@ -63,8 +63,8 @@
 <td align="center"><code><span class='Modifier2'>⟜</span></code></td>
 <td>Starling</td>
 <td><code><span class='Function'>S</span></code></td>
-<td>Dove</td>
-<td><code><span class='Function'>D</span></code></td>
+<td>~Dove</td>
+<td><code><span class='Function'>D</span></code>-like: <code><span class='Value'>labcd.ac</span><span class='Paren'>(</span><span class='Value'>bd</span><span class='Paren'>)</span></code></td>
 </tr>
 <tr>
 <td align="center"><code><span class='Modifier'>˜</span></code></td>

--- a/docs/doc/birds.html
+++ b/docs/doc/birds.html
@@ -55,9 +55,9 @@
 <tr>
 <td align="center"><code><span class='Modifier2'>⊸</span></code></td>
 <td></td>
-<td><code><span class='Function'>BSC</span></code></td>
+<td><code><span class='Function'>B1CBSC</span></code></td>
 <td>~Dove</td>
-<td><code><span class='Function'>D</span></code>-like: <code><span class='Value'>labcd.a</span><span class='Paren'>(</span><span class='Value'>bc</span><span class='Paren'>)</span><span class='Value'>d</span></code></td>
+<td><code><span class='Function'>D</span></code>-like: <code><span class='Value'>labcd.b</span><span class='Paren'>(</span><span class='Value'>ac</span><span class='Paren'>)</span><span class='Value'>d</span></code></td>
 </tr>
 <tr>
 <td align="center"><code><span class='Modifier2'>⟜</span></code></td>

--- a/docs/doc/birds.html
+++ b/docs/doc/birds.html
@@ -42,8 +42,8 @@
 <td align="center"><code><span class='Modifier2'>○</span></code></td>
 <td>Bluebird</td>
 <td><code><span class='Function'>B</span></code></td>
-<td>Psi?</td>
-<td><code><span class='Function'>D</span><span class='Value'>₂</span></code>-like: <code><span class='Value'>labcd.a</span><span class='Paren'>(</span><span class='Value'>bc</span><span class='Paren'>)(</span><span class='Value'>bd</span><span class='Paren'>)</span></code></td>
+<td>Psi</td>
+<td><code><span class='Value'>ψ</span></code></td>
 </tr>
 <tr>
 <td align="center"><code><span class='Modifier'>˙</span></code></td>
@@ -55,16 +55,16 @@
 <tr>
 <td align="center"><code><span class='Modifier2'>⊸</span></code></td>
 <td></td>
-<td><code><span class='Function'>R</span><span class='Value'>*</span><span class='Function'>S</span></code></td>
-<td>Queer</td>
-<td><code><span class='Function'>Q</span></code></td>
+<td><code><span class='Function'>BSC</span></code></td>
+<td>~Dove</td>
+<td><code><span class='Function'>D</span></code>-like: <code><span class='Value'>labcd.a</span><span class='Paren'>(</span><span class='Value'>bc</span><span class='Paren'>)</span><span class='Value'>d</span></code></td>
 </tr>
 <tr>
 <td align="center"><code><span class='Modifier2'>⟜</span></code></td>
 <td>Starling</td>
 <td><code><span class='Function'>S</span></code></td>
-<td>~Dove</td>
-<td><code><span class='Function'>D</span></code>-like: <code><span class='Value'>labcd.ac</span><span class='Paren'>(</span><span class='Value'>bd</span><span class='Paren'>)</span></code></td>
+<td>Dove</td>
+<td><code><span class='Function'>D</span></code></td>
 </tr>
 <tr>
 <td align="center"><code><span class='Modifier'>˜</span></code></td>
@@ -92,3 +92,8 @@
 <p>The name &quot;Golden Eagle&quot; is a <a href="https://nitter.net/code_report/status/1440208242529882112#m">fever dream</a> of bird enthusiast Conor Hoekstra, who saw it emerge disordered from the Bald Eagle when arguments <code><span class='Value'>fg</span></code> are set equal to <code><span class='Value'>cd</span></code>.</p>
 <p>Lambda calculus doesn't have BQN's polymorphism on one or two arguments, so each BQN combinator corresponds to two lambda calculus forms depending on the number of arguments, giving the two columns of birds above.</p>
 <p>Inputs are mapped to lambda calculus arguments according to the ordering <code><span class='Function'>𝔽𝔾</span><span class='Value'>𝕨𝕩</span></code>, and <code><span class='Function'>GFH</span></code> for a 3-train <code><span class='Function'>F</span> <span class='Function'>G</span> <span class='Function'>H</span></code>. For example, when I write that the combination <code><span class='Value'>𝕨</span> <span class='Function'>𝔽</span><span class='Modifier'>˜</span> <span class='Value'>𝕩</span></code> corresponds to a call of <code><span class='Function'>C</span></code> or <code><span class='Value'>labc.acb</span></code>, <code><span class='Value'>a</span></code> is <code><span class='Function'>𝔽</span></code> and <code><span class='Value'>bc</span></code> are <code><span class='Value'>𝕨𝕩</span></code>.</p>
+<p><strong>List of combinator bird compendiums:</strong></p>
+<ul>
+<li><a href="https://www.angelfire.com/tx4/cus/combinator/birds.html">Angelfire Combinator Birds</a></li>
+<li><a href="https://github.com/fantasyland/fantasy-birds">Fantasy Land Birds</a></li>
+</ul>


### PR DESCRIPTION
Things changed in this PR:
* Combinator bird name for `Psi` combinator is just `Psi` or `ψ`
* Before (or reflex hook in J speak) in BQN is not `R * S`. It is the `S` combinator with the binary function `flip`ped (or with `C` combinator). In Haskell this is spelled `(<*> . flip)` or using combinators `BSC`
* Dyadic before is `D`-like.
* Added list of combinator bird resources at the end

~~Sorry that I don't have CBQN downloaded locally to generate HTML.~~