### PR TITLE
Fix docs for first_pick's dyadic form

### DIFF
--- a/docs/help/first_pick.html
+++ b/docs/help/first_pick.html
@@ -18,7 +18,7 @@
 </pre>
 <h2 id="𝕨--𝕩-pick"><a class="header" href="#𝕨--𝕩-pick"><code><span class='Value'>𝕨</span> <span class='Function'>⊑</span> <span class='Value'>𝕩</span></code>: Pick</a></h2>
 <p><a class="fulldoc" href="../doc/pick.html">→full documentation</a></p>
-<p>Pick the element of <code><span class='Value'>𝕨</span></code> at index <code><span class='Value'>𝕩</span></code>.</p>
+<p>Pick the element of <code><span class='Value'>𝕩</span></code> at index <code><span class='Value'>𝕨</span></code>.</p>
 <a class="replLink" title="Open in the REPL" target="_blank" href="https://mlochbaum.github.io/BQN/try.html#code=MiDiipEg4p+oMSwgMiwgM+KfqQoKYiDihpAgM+KAvzMg4qWKIOKGlTkKCjLigL8wIOKKkSBi">↗️</a><pre>    <span class='Number'>2</span> <span class='Function'>⊑</span> <span class='Bracket'>⟨</span><span class='Number'>1</span><span class='Separator'>,</span> <span class='Number'>2</span><span class='Separator'>,</span> <span class='Number'>3</span><span class='Bracket'>⟩</span>
 3
 

--- a/help/first_pick.md
+++ b/help/first_pick.md
@@ -18,7 +18,7 @@ First element of `𝕩`.
 ## `𝕨 ⊑ 𝕩`: Pick
 [→full documentation](../doc/pick.md)
 
-Pick the element of `𝕨` at index `𝕩`.
+Pick the element of `𝕩` at index `𝕨`.
 
         2 ⊑ ⟨1, 2, 3⟩
 


### PR DESCRIPTION
Dyadic ⊑ takes an index as its first argument and the list as its second. In the documentation they were reversed.