### PR TITLE
Add mk12/aoc to list of AOC 2022 repos

### DIFF
--- a/community/aoc.md
+++ b/community/aoc.md
@@ -47,7 +47,8 @@
 [Doug Kelkhoff](https://github.com/dgkf/advent-of-code/tree/master/2022) •
 [Adam Juraszek](https://github.com/juriad/advent2022) •
 [Akshay Nair](https://github.com/phenax/advent-of-coolio-2022) •
-[Ben Dean](https://github.com/bddean/aoc/tree/main/2022)
+[Ben Dean](https://github.com/bddean/aoc/tree/main/2022) •
+[Mitchell Kember](https://github.com/mk12/aoc/tree/main/src/bqn)
 
 </center>
 


### PR DESCRIPTION
I've been having lots of fun doing AOC in BQN as well, currently on day 10.

(Not sure how you selected these repos so this might be a bit presumptuous, only merge if you want.)