### PR TITLE
Fix Vim status line errors when cursor is on empty line

### DIFF
--- a/editors/vim/autoload/bqn.vim
+++ b/editors/vim/autoload/bqn.vim
@@ -6,6 +6,6 @@ fu bqn#t() "toggle status line
  let&ls=2|let&stl='%{bqn#l()}'
 endf
 fu bqn#l() "render content of status line
- let c=substitute(getline('.')[col('.')-1:],'\(\_.\)\_.*','\1','')
+ let c=substitute(getline('.')[col('.')-1:]." ",'\(\_.\)\_.*','\1','')
  for x in s:a|if c=~#x[:len(c)-1]|retu x|en|endfo|retu c
 endf


### PR DESCRIPTION
This error is given by Vim 9.0 when BQN status line is active and cursor is moved over an empty line:

    Error detected while processing function bqn#l:
    line    2:
    E33: No previous substitute regular expression

This seems to happen when the result of substitution is empty, i.e. the pattern didn't match anything, or the expansion was the empty string.

Fix by appending a space to the line so substitute() always matches something.