### PR TITLE
docs: fix incorrect comment in block.md

### DIFF
--- a/doc/block.md
+++ b/doc/block.md
@@ -218,7 +218,7 @@ Destructuring with a header is limited, as it can only match a particular struct
 
         CheckPair ← { 𝕊⟨a,b⟩: a<b? "ok" ; "not ok" }
 
-        CheckPair ⟨3,8⟩    # Fails destructuring
+        CheckPair ⟨3,8⟩    # Succeeds destructuring
 
         CheckPair ⟨1,4,5⟩  # Not a pair
 


### PR DESCRIPTION
a comment in the tutorial appears to claim that "CheckPair ⟨3,8⟩" fails destructuring, when it clearly does not (and returns "ok", as seen in the rendered html)