### PR TITLE
bqn.js: JavaScript import module support

### DIFF
--- a/docs/bqn.js
+++ b/docs/bqn.js
@@ -508,7 +508,7 @@ let compgen = sys => {
 }
 let sysargs = {runtime, glyphs:glyphs.map(str)};
 let compile = compgen(sysargs)(sysargs);
-let bqn = src => run(...compile(src));
+export let bqn = src => run(...compile(src));
 runtime[43] = rtAssert;
 
 // Formatter


### PR DESCRIPTION
__What I want to do__

```
import { bqn } from "./libbqn.js";
```

__What I get instead__

```
Uncaught SyntaxError: The requested module 'http://localhost:8000/libbqn.js' doesn't provide an export named: 'bqn'
```

__What I expect to happen__

The single function relevant for my `main.js` to get loaded.

__Why this change__

While working on WASM-based tree-sitter support for BQN code highlighting for my blog ([demo here](https://juuso.dev/SPAs/apls/)), I ran into the convoluted world of modern JavaScript imports.

In my `main.js` file, when I run the `tsserver` LSP, I get these errors saying that `bqn` function does not exist, because my editor is not running in a browser context. In the browser the function is defined when the file is imported via the script tag and everything works.

To make the LSP happy, what can be done instead is to use the `import` feature to load the functions from some URI to "lift" the context of the LSP to the similar situation as the browser. However, this requires the variable to be prefixed with `export` in the source file. Once done, the `script` tag in HTML must be updated to include `type="module"` __if using an `import` statement in any other JS file__.

Even with the `export` change, a user does not need to update their JS import unless some other file is trying to read it using JS module features. In other words, introducing this change should not cause any apparent regressions, but only add features to those wanting to use modern JS.