### PR TITLE
Update Shift Before docs: move dyadic shiftbefore example into the dyadic section

### DIFF
--- a/docs/help/shiftbefore.html
+++ b/docs/help/shiftbefore.html
@@ -7,11 +7,8 @@
 <h1 id="left-pointing-double-angle-quotation-"><a class="header" href="#left-pointing-double-angle-quotation-">Left Pointing Double Angle Quotation (<code><span class='Function'>«</span></code>)</a></h1>
 <h2 id="-𝕩-nudge-back"><a class="header" href="#-𝕩-nudge-back"><code><span class='Function'>«</span> <span class='Value'>𝕩</span></code>: Nudge Back</a></h2>
 <p><a class="fulldoc" href="../doc/shift.html">→full documentation</a></p>
-<p>Remove the first element of <code><span class='Value'>𝕩</span></code>,  add a cell of fill values to the end of the first axis of <code><span class='Value'>𝕩</span></code>.</p>
-<a class="replLink" title="Open in the REPL" target="_blank" href="https://mlochbaum.github.io/BQN/try.html#code=NzggwqsgMeKAvzLigL8zCgrCqyAx4oC/MuKAvzMKCsKrIDPigL8zIOKliiA5">↗️</a><pre>    <span class='Number'>78</span> <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
-⟨ 2 3 78 ⟩
-
-    <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
+<p>Remove the first element of <code><span class='Value'>𝕩</span></code>, add a cell of fill values to the end of the first axis of <code><span class='Value'>𝕩</span></code>.</p>
+<a class="replLink" title="Open in the REPL" target="_blank" href="https://mlochbaum.github.io/BQN/try.html#code=wqsgMeKAvzLigL8zCgrCqyAz4oC/MyDipYogOQ==">↗️</a><pre>    <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
 ⟨ 2 3 0 ⟩
 
     <span class='Function'>«</span> <span class='Number'>3</span><span class='Ligature'>‿</span><span class='Number'>3</span> <span class='Function'>⥊</span> <span class='Number'>9</span>
@@ -24,7 +21,10 @@
 <h2 id="𝕨--𝕩-shift-before"><a class="header" href="#𝕨--𝕩-shift-before"><code><span class='Value'>𝕨</span> <span class='Function'>«</span> <span class='Value'>𝕩</span></code>: Shift Before</a></h2>
 <p><a class="fulldoc" href="../doc/shift.html">→full documentation</a></p>
 <p>Remove the first <code><span class='Function'>≠</span><span class='Value'>𝕨</span></code> (length) major cells from <code><span class='Value'>𝕩</span></code>, join <code><span class='Value'>𝕨</span></code> to the end of <code><span class='Value'>𝕩</span></code>. Ranks must match.</p>
-<a class="replLink" title="Open in the REPL" target="_blank" href="https://mlochbaum.github.io/BQN/try.html#code=OOKAvzUgwqsgMeKAvzLigL8zCgphIOKGkCAz4oC/MyDipYogOQoKMeKAvzLigL8zIMKrIGE=">↗️</a><pre>    <span class='Number'>8</span><span class='Ligature'>‿</span><span class='Number'>5</span> <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
+<a class="replLink" title="Open in the REPL" target="_blank" href="https://mlochbaum.github.io/BQN/try.html#code=NzggwqsgMeKAvzLigL8zCgo44oC/NSDCqyAx4oC/MuKAvzMKCmEg4oaQIDPigL8zIOKliiA5Cgox4oC/MuKAvzMgwqsgYQ==">↗️</a><pre>    <span class='Number'>78</span> <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
+⟨ 2 3 78 ⟩
+
+    <span class='Number'>8</span><span class='Ligature'>‿</span><span class='Number'>5</span> <span class='Function'>«</span> <span class='Number'>1</span><span class='Ligature'>‿</span><span class='Number'>2</span><span class='Ligature'>‿</span><span class='Number'>3</span>
 ⟨ 3 8 5 ⟩
 
     <span class='Value'>a</span> <span class='Gets'>←</span> <span class='Number'>3</span><span class='Ligature'>‿</span><span class='Number'>3</span> <span class='Function'>⥊</span> <span class='Number'>9</span>

--- a/help/shiftbefore.md
+++ b/help/shiftbefore.md
@@ -5,9 +5,7 @@
 ## `« 𝕩`: Nudge Back
 [→full documentation](../doc/shift.md)
 
-Remove the first element of `𝕩`,  add a cell of fill values to the end of the first axis of `𝕩`.
-
-        78 « 1‿2‿3
+Remove the first element of `𝕩`, add a cell of fill values to the end of the first axis of `𝕩`.
 
         « 1‿2‿3
 
@@ -19,6 +17,8 @@ Remove the first element of `𝕩`,  add a cell of fill values to the end of the
 [→full documentation](../doc/shift.md)
 
 Remove the first `≠𝕨` (length) major cells from `𝕩`, join `𝕨` to the end of `𝕩`. Ranks must match.
+
+        78 « 1‿2‿3
 
         8‿5 « 1‿2‿3
 


### PR DESCRIPTION
Hey there!

This PR moves the dyadic shiftbefore example from the monadic section. I think it was a mistake, but I'm not familar enough to say for sure!

---

Getting into BQN and enjoying it a lot! I _think_ all I had to do was update the `shiftbefore.md` and then run `gendocs`, so this does that. 

Couldn't figure out how to preview the HTML correctly, but assuming that's an issue on my end, the generated HTML seems correct! `python3 -m http.server` from the root is how I'm serving them in the screenshot

![image](https://github.com/user-attachments/assets/860455b5-1dd5-4625-8ad7-bfb3461dac4a)
