### PR TITLE
Include unicode DOM header in docs

### DIFF
--- a/docs/commentary/bacon.html
+++ b/docs/commentary/bacon.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: How to cook bacon</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/history.html
+++ b/docs/commentary/history.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN's development history</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/index.html
+++ b/docs/commentary/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN commentary</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/commentary/ltr.html
+++ b/docs/commentary/ltr.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left to right ordering?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/math.html
+++ b/docs/commentary/math.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Is BQN mathematics?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/orchard.html
+++ b/docs/commentary/orchard.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: The APL Orchard</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/overload.html
+++ b/docs/commentary/overload.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Primitive overloading</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/primitive.html
+++ b/docs/commentary/primitive.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: What is a primitive?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/problems.html
+++ b/docs/commentary/problems.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Problems with BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/stability.html
+++ b/docs/commentary/stability.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Is BQN stable?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/commentary/why.html
+++ b/docs/commentary/why.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Why use BQN?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">commentary</a></div>

--- a/docs/community/aoc.html
+++ b/docs/community/aoc.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Advent of Code</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">community</a></div>

--- a/docs/community/forums.html
+++ b/docs/community/forums.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN chat forums</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">community</a></div>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN community links</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/doc/arithmetic.html
+++ b/docs/doc/arithmetic.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Arithmetic functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/array.html
+++ b/docs/doc/array.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: The array</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/arrayrepr.html
+++ b/docs/doc/arrayrepr.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Array notation and display</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/assert.html
+++ b/docs/doc/assert.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Assert and Catch</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/based.html
+++ b/docs/doc/based.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Based array theory</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/birds.html
+++ b/docs/doc/birds.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN for birdwatchers</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/block.html
+++ b/docs/doc/block.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Blocks</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/choose.html
+++ b/docs/doc/choose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Choose</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/compose.html
+++ b/docs/doc/compose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Atop and Over</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/constant.html
+++ b/docs/doc/constant.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Constant</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/context.html
+++ b/docs/doc/context.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN's context-free grammar</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/control.html
+++ b/docs/doc/control.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Control flow in BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/couple.html
+++ b/docs/doc/couple.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Couple and Merge</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/depth.html
+++ b/docs/doc/depth.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Depth</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/embed.html
+++ b/docs/doc/embed.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Using embedded BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/enclose.html
+++ b/docs/doc/enclose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Enclose</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/expression.html
+++ b/docs/doc/expression.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Expression syntax</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/fill.html
+++ b/docs/doc/fill.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Fill elements</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/find.html
+++ b/docs/doc/find.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Find</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/fold.html
+++ b/docs/doc/fold.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Fold and Insert</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/fromDyalog.html
+++ b/docs/doc/fromDyalog.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN–Dyalog APL dictionary</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/fromJ.html
+++ b/docs/doc/fromJ.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN–J dictionary</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/functional.html
+++ b/docs/doc/functional.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Functional programming</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/glossary.html
+++ b/docs/doc/glossary.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN glossary</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/group.html
+++ b/docs/doc/group.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Group</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/hook.html
+++ b/docs/doc/hook.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Before and After</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/identity.html
+++ b/docs/doc/identity.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Identity functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/index.html
+++ b/docs/doc/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN documentation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/doc/indices.html
+++ b/docs/doc/indices.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Indices</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/join.html
+++ b/docs/doc/join.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Join and Join To</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/leading.html
+++ b/docs/doc/leading.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: The leading axis convention</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/lexical.html
+++ b/docs/doc/lexical.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Lexical scoping</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/logic.html
+++ b/docs/doc/logic.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Logic functions: And, Or, Not (also Span)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/map.html
+++ b/docs/doc/map.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mapping modifiers</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/match.html
+++ b/docs/doc/match.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Match</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/namespace.html
+++ b/docs/doc/namespace.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Namespaces</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/oop.html
+++ b/docs/doc/oop.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Object-oriented programming in BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/ops.html
+++ b/docs/doc/ops.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Functions and modifiers</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/order.html
+++ b/docs/doc/order.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Ordering functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/pair.html
+++ b/docs/doc/pair.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Pair</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/paradigms.html
+++ b/docs/doc/paradigms.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN in programming paradigms</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/pick.html
+++ b/docs/doc/pick.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Pick</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/prefixes.html
+++ b/docs/doc/prefixes.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Prefixes and Suffixes</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/primitive.html
+++ b/docs/doc/primitive.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN primitives</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/quick.html
+++ b/docs/doc/quick.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>A quick start to BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/range.html
+++ b/docs/doc/range.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Range</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/rank.html
+++ b/docs/doc/rank.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Cells and Rank</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/rebqn.html
+++ b/docs/doc/rebqn.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>ReBQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/repeat.html
+++ b/docs/doc/repeat.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Repeat</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/replicate.html
+++ b/docs/doc/replicate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Indices and Replicate</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/reshape.html
+++ b/docs/doc/reshape.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Deshape and Reshape</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/reverse.html
+++ b/docs/doc/reverse.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Reverse and Rotate</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/scan.html
+++ b/docs/doc/scan.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Scan</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/search.html
+++ b/docs/doc/search.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Search functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/select.html
+++ b/docs/doc/select.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Select</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/selfcmp.html
+++ b/docs/doc/selfcmp.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Self-search functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/shape.html
+++ b/docs/doc/shape.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Array dimensions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/shift.html
+++ b/docs/doc/shift.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Shift functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/swap.html
+++ b/docs/doc/swap.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Self and Swap</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/syntax.html
+++ b/docs/doc/syntax.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Syntax overview</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/tacit.html
+++ b/docs/doc/tacit.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Tacit programming</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/take.html
+++ b/docs/doc/take.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Take and Drop</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/token.html
+++ b/docs/doc/token.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Tokens</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/train.html
+++ b/docs/doc/train.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Function trains</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/transpose.html
+++ b/docs/doc/transpose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Transpose</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/types.html
+++ b/docs/doc/types.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Types</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/under.html
+++ b/docs/doc/under.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Under</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/undo.html
+++ b/docs/doc/undo.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Undo</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/valences.html
+++ b/docs/doc/valences.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Valences</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/doc/windows.html
+++ b/docs/doc/windows.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Windows</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">doc</a></div>

--- a/docs/editors/index.html
+++ b/docs/editors/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Editor support</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/help/2-modifierrightoperand.html
+++ b/docs/help/2-modifierrightoperand.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck G (𝔾)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/absolutevalue_modulus.html
+++ b/docs/help/absolutevalue_modulus.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Pipe (|)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/after_bind.html
+++ b/docs/help/after_bind.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Multimap (⟜)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/assert_assertwithmessage.html
+++ b/docs/help/assert_assertwithmessage.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Exclamation Mark (!)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/atop.html
+++ b/docs/help/atop.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Ring Operator (∘)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/before_bind.html
+++ b/docs/help/before_bind.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Multimap (⊸)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/beginarray.html
+++ b/docs/help/beginarray.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Square Bracket ([)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/beginblock.html
+++ b/docs/help/beginblock.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Curly Bracket ({)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/beginexpression.html
+++ b/docs/help/beginexpression.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Parenthesis (()</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/beginlist.html
+++ b/docs/help/beginlist.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Left Angle Bracket (⟨)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/catch.html
+++ b/docs/help/catch.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circled Triangle Down (⎊)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/ceiling_maximum.html
+++ b/docs/help/ceiling_maximum.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Ceiling (⌈)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/cells.html
+++ b/docs/help/cells.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Breve (˘)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/change.html
+++ b/docs/help/change.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Leftwards Arrow With Hook (↩)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/character.html
+++ b/docs/help/character.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Single Quote (')</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/choose.html
+++ b/docs/help/choose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle with Lower Right Quadrant (◶)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/classify_indexof.html
+++ b/docs/help/classify_indexof.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Square Original Of (⊐)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/comment.html
+++ b/docs/help/comment.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Number Sign (#)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/conjugate_add.html
+++ b/docs/help/conjugate_add.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Plus (+)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/constant.html
+++ b/docs/help/constant.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Dot Above (˙)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/currentfunction.html
+++ b/docs/help/currentfunction.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck S (𝕊)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/currentmodifier.html
+++ b/docs/help/currentmodifier.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck R (𝕣)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/deduplicate_find.html
+++ b/docs/help/deduplicate_find.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Epsilon Underbar (⍷)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/define.html
+++ b/docs/help/define.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Leftwards Arrow (←)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/depth.html
+++ b/docs/help/depth.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle With Two Dots (⚇)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/depth_match.html
+++ b/docs/help/depth_match.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Identical To (≡)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/deshape_reshape.html
+++ b/docs/help/deshape_reshape.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Barb (⥊)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/each.html
+++ b/docs/help/each.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Diaresis (¨)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/enclose_lessthan.html
+++ b/docs/help/enclose_lessthan.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Lesser Than (<)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/endarray.html
+++ b/docs/help/endarray.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Right Square Bracket (])</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/endblock.html
+++ b/docs/help/endblock.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Right Curly Bracket (})</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/endexpression.html
+++ b/docs/help/endexpression.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Right Parenthesis ())</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/endlist.html
+++ b/docs/help/endlist.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Right Angle Bracket (⟩)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/enlist_pair.html
+++ b/docs/help/enlist_pair.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Bow Tie (⋈)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/exponential_power.html
+++ b/docs/help/exponential_power.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Star (⋆)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/export.html
+++ b/docs/help/export.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Leftward Double Arrow (⇐)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/first_pick.html
+++ b/docs/help/first_pick.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Square Image Of Or Equal To (⊑)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/firstcell_select.html
+++ b/docs/help/firstcell_select.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Square Image Of (⊏)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/floor_minimum.html
+++ b/docs/help/floor_minimum.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Floor (⌊)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/fold.html
+++ b/docs/help/fold.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Acute Accent (´)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/gradedown_binsdown.html
+++ b/docs/help/gradedown_binsdown.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Del Stile (⍒)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/gradeup_binsup.html
+++ b/docs/help/gradeup_binsup.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Delta Stile (⍋)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/greaterthanorequalto.html
+++ b/docs/help/greaterthanorequalto.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Greater Than or Equal To (≥)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/groupindices_group.html
+++ b/docs/help/groupindices_group.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Square Cup (⊔)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/header.html
+++ b/docs/help/header.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Colon (:)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/identity_left.html
+++ b/docs/help/identity_left.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Tack (⊣)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/identity_right.html
+++ b/docs/help/identity_right.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Right Tack (⊢)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/index.html
+++ b/docs/help/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: REPL Help</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/help/indices_replicate.html
+++ b/docs/help/indices_replicate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Solidus (/)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/infinity.html
+++ b/docs/help/infinity.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Infinity (∞)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/insert.html
+++ b/docs/help/insert.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Double Acute Accent (˝)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/join_jointo.html
+++ b/docs/help/join_jointo.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Lazy S (∾)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/leftargument.html
+++ b/docs/help/leftargument.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck W (𝕨)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/length_notequals.html
+++ b/docs/help/length_notequals.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Not Equal (≠)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/lessthanorequalto.html
+++ b/docs/help/lessthanorequalto.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Lesser Than or Equal To (≤)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/markfirst_memberof.html
+++ b/docs/help/markfirst_memberof.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Element Of (∊)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/merge_greaterthan.html
+++ b/docs/help/merge_greaterthan.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Greater Than (>)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/minus.html
+++ b/docs/help/minus.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Macron (¯)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/modifierleftoperand.html
+++ b/docs/help/modifierleftoperand.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck F (𝔽)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/namespacefield.html
+++ b/docs/help/namespacefield.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Full Stop (.)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/negate_subtract.html
+++ b/docs/help/negate_subtract.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Minus (-)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/nextbody.html
+++ b/docs/help/nextbody.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Semicolon (;)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/not_span.html
+++ b/docs/help/not_span.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Not (¬)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/nothing.html
+++ b/docs/help/nothing.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Middle Dot (·)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/nullcharacter.html
+++ b/docs/help/nullcharacter.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Commercial At (@)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/occurrencecount_progressiveindexof.html
+++ b/docs/help/occurrencecount_progressiveindexof.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Square Original Of or Equal To (⊒)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/over.html
+++ b/docs/help/over.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle (○)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/pi.html
+++ b/docs/help/pi.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Pi (π)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/predicate.html
+++ b/docs/help/predicate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Question Mark (?)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/prefixes_take.html
+++ b/docs/help/prefixes_take.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Up Arrow (↑)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/range_windows.html
+++ b/docs/help/range_windows.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Up Down Arrow (↕)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/rank.html
+++ b/docs/help/rank.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circled Horizontal Bar With Notch (⎉)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/rank_equals.html
+++ b/docs/help/rank_equals.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Equal (=)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/reciprocal_divide.html
+++ b/docs/help/reciprocal_divide.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Divide (÷)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/repeat.html
+++ b/docs/help/repeat.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle Star (⍟)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/reverse_rotate.html
+++ b/docs/help/reverse_rotate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle Stile (⌽)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/rightargument.html
+++ b/docs/help/rightargument.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Mathematical Double-struck X (𝕩)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/scan.html
+++ b/docs/help/scan.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Grave (`)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/self_swap.html
+++ b/docs/help/self_swap.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Small Tilde (˜)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/separator.html
+++ b/docs/help/separator.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Comma (,) and Diamond (⋄)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/shape_notmatch.html
+++ b/docs/help/shape_notmatch.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Not Identical To (≢)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/shiftafter.html
+++ b/docs/help/shiftafter.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Right Pointing Double Angle Quotation (»)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/shiftbefore.html
+++ b/docs/help/shiftbefore.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Left Pointing Double Angle Quotation («)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/sign_multiply.html
+++ b/docs/help/sign_multiply.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Times (×)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/solo_couple.html
+++ b/docs/help/solo_couple.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Tape (≍)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/sortdown_or.html
+++ b/docs/help/sortdown_or.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Logical Or (∨)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/sortup_and.html
+++ b/docs/help/sortup_and.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Logical And (∧)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/squareroot_root.html
+++ b/docs/help/squareroot_root.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Root (√)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/strand.html
+++ b/docs/help/strand.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Undertie (‿)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/string.html
+++ b/docs/help/string.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Double Quote (")</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/suffixes_drop.html
+++ b/docs/help/suffixes_drop.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Down Arrow (↓)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/system.html
+++ b/docs/help/system.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Bullet (•)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/table.html
+++ b/docs/help/table.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Top Left Corner (⌜)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/transpose_reorderaxes.html
+++ b/docs/help/transpose_reorderaxes.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle Backslash (⍉)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/under.html
+++ b/docs/help/under.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circle Jot (⌾)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/undo.html
+++ b/docs/help/undo.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Superscript Equals Sign (⁼)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/help/valences.html
+++ b/docs/help/valences.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Circled Division Slash (⊘)</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">help</a></div>

--- a/docs/implementation/bootbench.html
+++ b/docs/implementation/bootbench.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Bootstrapping compiler benchmarks</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/implementation/codfns.html
+++ b/docs/implementation/codfns.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Co-dfns versus BQN's implementation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/implementation/compile/dynamic.html
+++ b/docs/implementation/compile/dynamic.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Dynamic compilation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">compile</a></div>

--- a/docs/implementation/compile/index.html
+++ b/docs/implementation/compile/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Optimizing compilation notes</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a></div>

--- a/docs/implementation/compile/intro.html
+++ b/docs/implementation/compile/intro.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Array language compilation in context</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">compile</a></div>

--- a/docs/implementation/index.html
+++ b/docs/implementation/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN implementation notes</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/implementation/kclaims.html
+++ b/docs/implementation/kclaims.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Wild claims about K performance</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/implementation/perf.html
+++ b/docs/implementation/perf.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>How does BQN perform?</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/implementation/primitive/arithmetic.html
+++ b/docs/implementation/primitive/arithmetic.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of arithmetic</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/flagsort.html
+++ b/docs/implementation/primitive/flagsort.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Sortedness flags in primitive implementation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/fold.html
+++ b/docs/implementation/primitive/fold.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of Fold and Scan</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/index.html
+++ b/docs/implementation/primitive/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Primitive implementation notes</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a></div>

--- a/docs/implementation/primitive/random.html
+++ b/docs/implementation/primitive/random.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of random stuff</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/replicate.html
+++ b/docs/implementation/primitive/replicate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of Indices and Replicate</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/search.html
+++ b/docs/implementation/primitive/search.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of search functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/select.html
+++ b/docs/implementation/primitive/select.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of Select</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/sort.html
+++ b/docs/implementation/primitive/sort.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of ordering functions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/take.html
+++ b/docs/implementation/primitive/take.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of Take and Drop</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/primitive/transpose.html
+++ b/docs/implementation/primitive/transpose.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: Implementation of array transpose</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../../index.html">BQN</a> / <a href="../index.html">implementation</a> / <a href="index.html">primitive</a></div>

--- a/docs/implementation/versusc.html
+++ b/docs/implementation/versusc.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Performance in BQN versus C</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/implementation/vm.html
+++ b/docs/implementation/vm.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>The BQN virtual machine and runtime</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">implementation</a></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN: finally, an APL for your flying saucer</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>)</div>

--- a/docs/keymap.html
+++ b/docs/keymap.html
@@ -1,6 +1,7 @@
 <head>
   <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN keymap</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="index.html">BQN</a></div>

--- a/docs/running.html
+++ b/docs/running.html
@@ -1,6 +1,7 @@
 <head>
   <link href="favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>How to run BQN</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="index.html">BQN</a></div>

--- a/docs/spec/complex.html
+++ b/docs/spec/complex.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Specification: Complex numbers</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/evaluate.html
+++ b/docs/spec/evaluate.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN evaluation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/grammar.html
+++ b/docs/spec/grammar.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN grammar</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN specification</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/spec/inferred.html
+++ b/docs/spec/inferred.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN inferred properties</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/literal.html
+++ b/docs/spec/literal.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN literal notation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/primitive.html
+++ b/docs/spec/primitive.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN primitives</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/scope.html
+++ b/docs/spec/scope.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN variable scoping</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/system.html
+++ b/docs/spec/system.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN system-provided values</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/token.html
+++ b/docs/spec/token.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN token formation</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/spec/types.html
+++ b/docs/spec/types.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Specification: BQN types</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">spec</a></div>

--- a/docs/tutorial/combinator.html
+++ b/docs/tutorial/combinator.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Tutorial: Combinators</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">tutorial</a></div>

--- a/docs/tutorial/expression.html
+++ b/docs/tutorial/expression.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>Tutorial: BQN expressions</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">tutorial</a></div>

--- a/docs/tutorial/index.html
+++ b/docs/tutorial/index.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN tutorials</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a></div>

--- a/docs/tutorial/list.html
+++ b/docs/tutorial/list.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Tutorial: Working with lists</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">tutorial</a></div>

--- a/docs/tutorial/variable.html
+++ b/docs/tutorial/variable.html
@@ -1,6 +1,7 @@
 <head>
   <link href="../favicon.ico" rel="shortcut icon" type="image/x-icon"/>
   <link href="../style.css" rel="stylesheet"/>
+  <meta charset="utf-8">
   <title>BQN Tutorial: Variables</title>
 </head>
 <div class="nav">(<a href="https://github.com/mlochbaum/BQN">github</a>) / <a href="../index.html">BQN</a> / <a href="index.html">tutorial</a></div>

--- a/md.bqn
+++ b/md.bqn
@@ -725,6 +725,7 @@ ConvertFile ← {
   head ← "head" Html lf∾JoinLines "  "⊸∾¨⟨
     "shortcut icon' type='image/x-icon" Link "favicon.ico"
     "stylesheet" Link "style.css"
+    RQ "<meta charset='utf-8'>"
     "title" Html ("BQN"∾":"⊸(¬∘∊/⊣)∾" "∾⊢)⍟(¬·∨´"BQN"⍷⊢) Clean 2↓⊑h1
   ⟩
   repo ← "("∾")"∾˜ "a href='"‿repoURL‿"'" ∾⊸Html "github"


### PR DESCRIPTION
Certain HTTP servers don't set the charset, so this updates `mb.bqn` to include a `meta` tag that does just that. 
It allows `python -m http.server` to host the docs in dev environments with the glyphs rendered.

![image](https://github.com/user-attachments/assets/fb616418-d6c7-4192-9df7-3aa9848fc382)

Thanks to @dzaima in #100 for guidance!