### PR TITLE
Amend typo of VARO as VARM in VM docs

### DIFF
--- a/docs/implementation/vm.html
+++ b/docs/implementation/vm.html
@@ -261,7 +261,7 @@
 <td align="right">22</td>
 <td>VARU</td>
 <td align="center">X</td>
-<td align="right">21</td>
+<td align="right">20</td>
 <td align="left"><code><span class='Function'>D</span></code>, <code><span class='Function'>I</span></code></td>
 <td>Push and clear local variable <code><span class='Function'>I</span></code> from <code><span class='Function'>D</span></code> frames up</td>
 </tr>
@@ -371,7 +371,7 @@
 </tr>
 </tbody>
 </table>
-<p>Stack effects for most instructions are given below. Instructions <code><span class='Function'>FN1O</span></code>, <code><span class='Function'>FN2O</span></code>, and <code><span class='Function'>TR3O</span></code> are identical to <code><span class='Function'>FN1C</span></code>, <code><span class='Function'>FN2C</span></code>, and <code><span class='Function'>TR3D</span></code> except that the indicated values in the higher-numbered instructions may be <code><span class='Nothing'>·</span></code>. The non-checking instructions can be implemented using the checking ones, but avoiding the check could improve speed. <code><span class='Function'>VARU</span></code> is identical to <code><span class='Function'>VARM</span></code> but indicates that the local variable's value will never be used again, which may be useful for optimization.</p>
+<p>Stack effects for most instructions are given below. Instructions <code><span class='Function'>FN1O</span></code>, <code><span class='Function'>FN2O</span></code>, and <code><span class='Function'>TR3O</span></code> are identical to <code><span class='Function'>FN1C</span></code>, <code><span class='Function'>FN2C</span></code>, and <code><span class='Function'>TR3D</span></code> except that the indicated values in the higher-numbered instructions may be <code><span class='Nothing'>·</span></code>. The non-checking instructions can be implemented using the checking ones, but avoiding the check could improve speed. <code><span class='Function'>VARU</span></code> is identical to <code><span class='Function'>VARO</span></code> but indicates that the local variable's value will never be used again, which may be useful for optimization.</p>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
The VM page looks like it might be generated from something else but I couldn't find a source, sorry if this is the wrong way to do things

I've changed "VARU is identical to VARM except [..]" to read "VARU is identical to VARO except [..]" and also pointed its "like" column of the instructions table at VARO